### PR TITLE
easy_install is throwing errors because pip switched from HTTP to HTT…

### DIFF
--- a/lib/vagrant-guest_ansible/guest_script.sh
+++ b/lib/vagrant-guest_ansible/guest_script.sh
@@ -27,10 +27,9 @@ if ! command -v ansible >/dev/null; then
                 echo "neither yum nor apt-get found!"
                 exit 1
         fi
-        echo "Installing pip via easy_install."
-        wget http://peak.telecommunity.com/dist/ez_setup.py
-        sudo python ez_setup.py && rm -f ez_setup.py
-        sudo easy_install pip
+        echo "Installing pip via get-pip."
+        wget https://bootstrap.pypa.io/get-pip.py
+        sudo python get-pip.py && rm -f get-pip.py
         # Make sure setuptools are installed crrectly.
         sudo pip install setuptools --no-use-wheel --upgrade
         echo "Installing required python modules."


### PR DESCRIPTION
…PS. Modify to use official install method for pip.